### PR TITLE
JDOC-788, JDOC-789, JDOC-791, JDOC-792

### DIFF
--- a/src/components/ApiInfo/ApiInfo.styles.scss
+++ b/src/components/ApiInfo/ApiInfo.styles.scss
@@ -17,4 +17,8 @@
   .description {
     color: $secondary-text;
   }
+
+  &.hidden {
+    display: none;
+  }
 }

--- a/src/components/ApiInfo/index.tsx
+++ b/src/components/ApiInfo/index.tsx
@@ -1,4 +1,5 @@
 import React, {useEffect} from 'react';
+import clsx from 'clsx';
 import {ApiInfoType} from 'types/exchange';
 import {Description} from '../Description';
 import './ApiInfo.styles.scss';
@@ -7,9 +8,10 @@ const DEFAULT_TITLE = 'JSight Online Editor';
 
 interface ApiInfoProps {
   apiInfo?: ApiInfoType;
+  hidden?: boolean;
 }
 
-export const ApiInfo = ({apiInfo}: ApiInfoProps) => {
+export const ApiInfo = ({apiInfo, hidden}: ApiInfoProps) => {
   useEffect(() => {
     document.title = apiInfo?.title || DEFAULT_TITLE;
     return () => {
@@ -18,7 +20,7 @@ export const ApiInfo = ({apiInfo}: ApiInfoProps) => {
   }, [apiInfo?.title]);
 
   return apiInfo ? (
-    <div className="api-info">
+    <div className={clsx('api-info', {hidden})}>
       <h1>{apiInfo.title}</h1>
       {apiInfo.version && (
         <div className="version">

--- a/src/components/CodeView/Code.tsx
+++ b/src/components/CodeView/Code.tsx
@@ -68,7 +68,12 @@ export const Code = ({schema, tab, codeViewRef, keyBlock}: CodeProps) => {
   const [height, setHeight] = useState<number>(0);
   const {selectedLine, setSchemasData, schemasData} = useContext(MainContext);
   const {expandedTypes} = useContext(SchemaViewContext);
-  const {currentDocSidebar, setCurrentDocSidebar} = useContext(SidebarContext);
+  const {
+    currentDocSidebar,
+    setCurrentDocSidebar,
+    currentHtmlDocPanel,
+    setCurrentHtmlDocPanel,
+  } = useContext(SidebarContext);
   const [isFirst, setIsFirst] = useState<boolean>(true);
 
   const schemaData = useMemo(() => {
@@ -197,8 +202,8 @@ export const Code = ({schema, tab, codeViewRef, keyBlock}: CodeProps) => {
 
   // when active live with rules is changed
   useEffect(() => {
-    if (selectedLine && currentDocSidebar !== 'content') {
-      setCurrentDocSidebar('rules');
+    if (selectedLine && currentHtmlDocPanel !== 'content') {
+      setCurrentHtmlDocPanel('rules');
     } else {
       setHeight((codeViewRef.current?.getBoundingClientRect().height || 0) + 65);
     }

--- a/src/components/CodeView/DetailCard/index.tsx
+++ b/src/components/CodeView/DetailCard/index.tsx
@@ -33,7 +33,7 @@ export const DetailCard = ({
   keyBlock,
 }: DetailCardProps) => {
   const divRef = useRef<HTMLDivElement | null>(null);
-  const {setCurrentDocSidebar} = useContext(SidebarContext);
+  const {setCurrentHtmlDocPanel} = useContext(SidebarContext);
   const {setSelectedLine} = useContext(MainContext);
 
   const renderRule = (rule: RuleType, key: string, rulesLength: number, index: number) => {
@@ -80,7 +80,7 @@ export const DetailCard = ({
   };
 
   const closeDetailCard = () => {
-    setCurrentDocSidebar('htmldoc');
+    setCurrentHtmlDocPanel('none');
     setSelectedLine(null);
   };
 

--- a/src/components/CodeView/RightRules.tsx
+++ b/src/components/CodeView/RightRules.tsx
@@ -24,7 +24,7 @@ export const RightRules: FC<RightRulesProps> = ({
   isFirst,
 }) => {
   const divRulesRef = useRef<HTMLDivElement | null>(null);
-  const {currentDocSidebar} = useContext(SidebarContext);
+  const {currentHtmlDocPanel} = useContext(SidebarContext);
   const {selectedLine} = useContext(MainContext);
   const [topOffset, setTopOffset] = useState<number>(0);
   const [rightOffset, setRightOffset] = useState<number>(0);
@@ -43,7 +43,7 @@ export const RightRules: FC<RightRulesProps> = ({
     const rightOffset = wrapper ? parseInt(getComputedStyle(wrapper).paddingRight) : 0;
     setRightOffset(rightOffset);
 
-    if (selectedLine?.keyBlock === keyBlock && currentDocSidebar === 'rules') {
+    if (selectedLine?.keyBlock === keyBlock && currentHtmlDocPanel === 'rules') {
       const detailActiveElements = divRulesRef.current?.querySelectorAll<HTMLSpanElement>(
         `[data-name="line-${selectedLine.numberLine}"]`
       );
@@ -82,10 +82,10 @@ export const RightRules: FC<RightRulesProps> = ({
         updateHeight(detailActiveElement, codeLineDocumentOffset);
       }
     }
-  }, [selectedLine, currentDocSidebar, keyBlock]);
+  }, [selectedLine, currentHtmlDocPanel, keyBlock]);
 
   const updateDetailWrapperHeight = () => {
-    if (selectedLine?.keyBlock === keyBlock && currentDocSidebar === 'rules') {
+    if (selectedLine?.keyBlock === keyBlock && currentHtmlDocPanel === 'rules') {
       const detailActiveElements = divRulesRef.current?.querySelectorAll<HTMLSpanElement>(
         `[data-name="line-${selectedLine.numberLine}"]`
       );
@@ -138,7 +138,7 @@ export const RightRules: FC<RightRulesProps> = ({
     <div
       className="right-rules-wrapper"
       style={{
-        display: currentDocSidebar === 'rules' ? 'block' : 'none',
+        display: currentHtmlDocPanel === 'rules' ? 'block' : 'none',
         width: rightWidth || 0,
         right: offsetLeft || 0,
         height,

--- a/src/components/CodeView/hooks/useSelectionLine.ts
+++ b/src/components/CodeView/hooks/useSelectionLine.ts
@@ -29,7 +29,7 @@ export function useSelectionLine({
   const {setSelectedLine, selectedLine} = useContext(MainContext);
   const {collapsedRules} = useContext(SchemaViewContext);
   const {hoveredSchema, hiddenInheritedSchemas, keyBlock} = useContext(CodeContext);
-  const {setCurrentDocSidebar} = useContext(SidebarContext);
+  const {setCurrentDocSidebar, setCurrentHtmlDocPanel} = useContext(SidebarContext);
   const isShowDetailInfo = useShowDetailInfo(rules, notes);
 
   const isSelected = useMemo(
@@ -59,7 +59,7 @@ export function useSelectionLine({
           return null;
         }
 
-        setCurrentDocSidebar('rules');
+        setCurrentHtmlDocPanel('rules');
         return {
           numberLine,
           keyBlock,

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -9,8 +9,10 @@ interface LayoutProps {
 }
 
 export const Layout = ({children, isEditor}: LayoutProps) => {
-  const {currentDocSidebar} = useContext(SidebarContext);
-  const isShowSidebar = isEditor ? currentDocSidebar === 'content' : true;
+  const {currentDocSidebar, currentHtmlDocPanel} = useContext(SidebarContext);
+  const isShowSidebar = isEditor
+    ? currentHtmlDocPanel === 'content' && currentDocSidebar === 'htmldoc'
+    : true;
   const side = isEditor ? 'right' : 'left';
 
   return (

--- a/src/components/MainContent/index.tsx
+++ b/src/components/MainContent/index.tsx
@@ -62,9 +62,12 @@ export const MainContent = React.memo((props: MainContentProps) => {
     GlobalSettingsContext
   );
   const {currentUrl, setCurrentUrl} = useContext(CurrentUrlContext);
-  const {currentDocSidebar, setCurrentDocSidebar, currentOpenApiFormat} = useContext(
-    SidebarContext
-  );
+  const {
+    currentDocSidebar,
+    currentOpenApiFormat,
+    currentHtmlDocPanel,
+    setCurrentHtmlDocPanel,
+  } = useContext(SidebarContext);
   const [overscan, setOverscan] = useState(480);
   const [schemasView, setSchemasView] = useState<SchemaViewType[]>([]);
   const [schemasData, setSchemasData] = useState<{[key: string]: SchemaData[]}>({});
@@ -410,6 +413,11 @@ export const MainContent = React.memo((props: MainContentProps) => {
       <div className={mainContentClasses}>
         {currentDocSidebar === 'openapi' && viewMode !== 'doc' && (
           <div className="openapi-wrapper">
+            <ApiInfo
+              apiInfo={{title: jdocExchange?.info?.title || 'JSight Online Editor'}}
+              key="apiInfo"
+              hidden
+            />
             <div className="openapi-lines">
               {Array.from(Array(openApiLinesCount).keys()).map((num) => (
                 <Fragment key={num + 1}>
@@ -427,7 +435,7 @@ export const MainContent = React.memo((props: MainContentProps) => {
         )}
         {(currentDocSidebar !== 'openapi' || viewMode === 'doc') && (
           <MainContext.Provider value={value}>
-            {currentDocSidebar === 'rules' && (
+            {currentHtmlDocPanel === 'rules' && (
               <button
                 style={{
                   right: `${
@@ -438,7 +446,7 @@ export const MainContent = React.memo((props: MainContentProps) => {
                 }}
                 className="sidebar-rules-close"
                 onClick={() => {
-                  setCurrentDocSidebar('htmldoc');
+                  setCurrentHtmlDocPanel('none');
                   setSelectedLine(null);
                 }}
               >

--- a/src/components/SidebarContent/index.tsx
+++ b/src/components/SidebarContent/index.tsx
@@ -19,7 +19,7 @@ interface SidebarContentProps {
 
 export const SidebarContent = ({side, isShowSettings, isShow}: SidebarContentProps) => {
   const {setIsOpen, isOpen} = useContext(GlobalSettingsContext);
-  const {setCurrentDocSidebar} = useContext(SidebarContext);
+  const {setCurrentHtmlDocPanel} = useContext(SidebarContext);
   const {jdocExchange: jdocData} = useContext(JDocContext);
 
   const tags = useMemo(() => jdocData?.tags || {}, [jdocData]);
@@ -48,7 +48,7 @@ export const SidebarContent = ({side, isShowSettings, isShow}: SidebarContentPro
             <i className="icon-menu" /> <h2>Contents</h2>
           </div>
           {!(side === 'left' || isExport) && (
-            <button onClick={() => setCurrentDocSidebar('htmldoc')}>
+            <button onClick={() => setCurrentHtmlDocPanel('none')}>
               <i className="icon-close" />
             </button>
           )}

--- a/src/screens/Editor/EditorScreen.export.tsx
+++ b/src/screens/Editor/EditorScreen.export.tsx
@@ -8,7 +8,7 @@ import './Editor.styles.scss';
 import 'react-toastify/dist/ReactToastify.css';
 import {Contacts} from 'components/Modals/Contacts';
 import {screenWidthMultiplier} from 'utils/screenWidthMultiplier';
-import {editorModeType, ErrorType, SidebarDocType} from 'types';
+import {editorModeType, ErrorType, HtmlDocPanelType, SidebarDocType} from 'types';
 import {JDocContext, SidebarContext, EditorContext, CurrentUrlProvider} from 'store';
 import {showEditorError} from 'utils/showEditorError';
 import {useDebounce} from 'hooks/useDebounce';
@@ -27,6 +27,7 @@ export const EditorScreen = () => {
 
   //documentation sidebar on the right
   const [currentDocSidebar, setCurrentDocSidebar] = useState<SidebarDocType>('htmldoc');
+  const [currentHtmlDocPanel, setCurrentHtmlDocPanel] = useState<HtmlDocPanelType>('none');
   const [jdocExchange, setJdocExchange] = useState<JDocType>();
   const jsightCodeDebounced = useDebounce<string>(jsightCode, 600);
   const [contactModalVisible, setContactModalVisible] = useState<boolean>(false);
@@ -79,15 +80,15 @@ export const EditorScreen = () => {
     () =>
       clsx({
         'editor-wrapper-inner': true,
-        'rules-sidebar': currentDocSidebar === 'rules',
-        'content-sidebar': currentDocSidebar === 'content',
+        'rules-sidebar': currentHtmlDocPanel === 'rules',
+        'content-sidebar': currentHtmlDocPanel === 'content',
         'code-sidebar': codeContentsSidebar,
       }),
-    [codeContentsSidebar, currentDocSidebar]
+    [codeContentsSidebar, currentHtmlDocPanel]
   );
 
-  const handleCurrentDocSidebar = useCallback((sidebar: SidebarDocType) => {
-    setCurrentDocSidebar((prev) => (prev === sidebar ? 'htmldoc' : sidebar));
+  const handleCurrentHtmlDocPanel = useCallback((htmldocpanel: HtmlDocPanelType) => {
+    setCurrentHtmlDocPanel((prev) => (prev === htmldocpanel ? 'none' : htmldocpanel));
   }, []);
 
   const jdocValue = useMemo(
@@ -102,8 +103,10 @@ export const EditorScreen = () => {
     () => ({
       currentDocSidebar,
       setCurrentDocSidebar,
+      currentHtmlDocPanel,
+      setCurrentHtmlDocPanel,
     }),
-    [currentDocSidebar]
+    [currentDocSidebar, currentHtmlDocPanel]
   );
 
   const editorValue = useMemo(
@@ -140,9 +143,9 @@ export const EditorScreen = () => {
               {isEditor && (
                 <div className="side-panel right-side">
                   <div
-                    onClick={() => handleCurrentDocSidebar('content')}
+                    onClick={() => handleCurrentHtmlDocPanel('content')}
                     className={clsx('side-panel-element', {
-                      active: currentDocSidebar === 'content',
+                      active: currentHtmlDocPanel === 'content',
                     })}
                   >
                     <i className="icon-list" /> Contents

--- a/src/screens/Editor/index.tsx
+++ b/src/screens/Editor/index.tsx
@@ -14,10 +14,17 @@ import {initCats, initDogs, initPigs, initJsonRpc} from './init';
 import {Contacts} from 'components/Modals/Contacts';
 import {HeaderDoc} from 'components/Header/HeaderDoc';
 import {screenWidthMultiplier} from 'utils/screenWidthMultiplier';
-import {editorModeType, ExamplesType, OpenApiFormatType, SidebarDocType} from 'types';
+import {
+  editorModeType,
+  ExamplesType,
+  OpenApiFormatType,
+  SidebarDocType,
+  HtmlDocPanelType,
+} from 'types';
 import {EditorContext, JDocContext, SidebarContext, SharingContext} from 'store';
 import {CurrentUrlProvider} from 'store/CurrentUrlStore';
 import {onOrientationChange} from 'utils/onOrientationChange';
+import {notificationIds} from 'utils/notificationIds';
 import {ErrorScreen} from 'screens/Error';
 import {SharingForm} from 'components/Modals/SharingForm';
 import 'react-toastify/dist/ReactToastify.css';
@@ -29,7 +36,6 @@ import IconHTMLDoc from 'assets/images/icons/htmldoc.svg';
 import IconContents from 'assets/images/icons/contents.svg';
 
 import './Editor.styles.scss';
-import {notificationIds} from 'utils/notificationIds';
 
 const {isExport} = window as any;
 
@@ -47,6 +53,7 @@ export const EditorScreen = () => {
   //documentation sidebar on the right
   const [currentDocSidebar, setCurrentDocSidebar] = useState<SidebarDocType>('htmldoc');
   const [currentOpenApiFormat, setCurrentOpenApiFormat] = useState<OpenApiFormatType>('yaml');
+  const [currentHtmlDocPanel, setCurrentHtmlDocPanel] = useState<HtmlDocPanelType>('none');
   const [jdocExchange, setJdocExchange] = useState<JDocType>();
   const [errorRow, setErrorRow] = useState<number | null>(null);
   const [scrollToRow, setScrollToRow] = useState<boolean>(false);
@@ -153,11 +160,11 @@ export const EditorScreen = () => {
     () =>
       clsx({
         'editor-wrapper-inner': true,
-        'rules-sidebar': currentDocSidebar === 'rules',
-        'content-sidebar': currentDocSidebar === 'content',
+        'rules-sidebar': currentHtmlDocPanel === 'rules',
+        'content-sidebar': currentHtmlDocPanel === 'content',
         'code-sidebar': codeContentsSidebar,
       }),
-    [codeContentsSidebar, currentDocSidebar]
+    [codeContentsSidebar, currentHtmlDocPanel]
   );
 
   const setInitJsightCode = (code: string) => {
@@ -199,6 +206,10 @@ export const EditorScreen = () => {
     setCurrentDocSidebar((prev) => (prev === sidebar ? 'htmldoc' : sidebar));
   }, []);
 
+  const handleCurrentHtmlDocPanel = useCallback((htmldocpanel: HtmlDocPanelType) => {
+    setCurrentHtmlDocPanel((prev) => (prev === htmldocpanel ? 'none' : htmldocpanel));
+  }, []);
+
   const handleJsightCode = useCallback((code: string) => setJsightCode(code), []);
   const handleDisableSharing = useCallback((value) => setDisableSharing(value), []);
   const handleError = useCallback((error) => setError(error), []);
@@ -218,8 +229,10 @@ export const EditorScreen = () => {
       setCurrentDocSidebar,
       currentOpenApiFormat,
       setCurrentOpenApiFormat,
+      currentHtmlDocPanel,
+      setCurrentHtmlDocPanel,
     }),
-    [currentDocSidebar, currentOpenApiFormat]
+    [currentDocSidebar, currentOpenApiFormat, currentHtmlDocPanel]
   );
 
   const editorValue = useMemo(
@@ -332,19 +345,18 @@ export const EditorScreen = () => {
                     onClick={() => handleCurrentDocSidebar('htmldoc')}
                     className={clsx('side-panel-element', {
                       active:
-                        currentDocSidebar === 'htmldoc' ||
-                        currentDocSidebar === 'rules' ||
-                        currentDocSidebar === 'content',
+                        currentDocSidebar === 'htmldoc' &&
+                        (currentHtmlDocPanel === 'rules' || currentHtmlDocPanel === 'content'),
                     })}
                   >
                     <img src={IconHTMLDoc} alt="HTMLDoc" /> HTML Doc
                   </div>
                   <div
                     onClick={() =>
-                      currentDocSidebar !== 'openapi' && handleCurrentDocSidebar('content')
+                      currentDocSidebar !== 'openapi' && handleCurrentHtmlDocPanel('content')
                     }
                     className={clsx('side-panel-element', {
-                      active: currentDocSidebar === 'content',
+                      active: currentHtmlDocPanel === 'content',
                       disabled: currentDocSidebar === 'openapi',
                     })}
                     title={

--- a/src/store/SidebarStore.ts
+++ b/src/store/SidebarStore.ts
@@ -1,11 +1,14 @@
 import React, {createContext} from 'react';
 import {OpenApiFormatType, SidebarDocType} from 'types';
+import {HtmlDocPanelType} from 'types/htmldocpanel';
 
 interface SidebarContextInterface {
-  currentOpenApiFormat?: OpenApiFormatType;
-  setCurrentOpenApiFormat?: React.Dispatch<React.SetStateAction<OpenApiFormatType>>;
   currentDocSidebar: SidebarDocType;
   setCurrentDocSidebar: React.Dispatch<React.SetStateAction<SidebarDocType>>;
+  currentHtmlDocPanel: HtmlDocPanelType;
+  setCurrentHtmlDocPanel: React.Dispatch<React.SetStateAction<HtmlDocPanelType>>;
+  currentOpenApiFormat?: OpenApiFormatType;
+  setCurrentOpenApiFormat?: React.Dispatch<React.SetStateAction<OpenApiFormatType>>;
 }
 
 export const SidebarContext = createContext({} as SidebarContextInterface);

--- a/src/types/htmldocpanel.ts
+++ b/src/types/htmldocpanel.ts
@@ -1,0 +1,1 @@
+export type HtmlDocPanelType = 'none' | 'content' | 'rules';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,7 @@ export * from './editor';
 export * from './error';
 export * from './router';
 export * from './sidebar';
+export * from './htmldocpanel';
 export * from './exchange';
 export * from './header';
 export * from './converter';

--- a/src/types/sidebar.ts
+++ b/src/types/sidebar.ts
@@ -1,1 +1,1 @@
-export type SidebarDocType = 'content' | 'rules' | 'openapi' | 'htmldoc';
+export type SidebarDocType = 'openapi' | 'htmldoc';

--- a/src/utils/getError.ts
+++ b/src/utils/getError.ts
@@ -7,7 +7,9 @@ export const getErrorTitle = (error: ErrorType | undefined) => {
 
 export const getError = (error: ErrorType) => {
   const errorMessage = error.Message;
-  return errorMessage.charAt(0).toUpperCase() + errorMessage.slice(1);
+  return errorMessage
+    ? errorMessage.charAt(0).toUpperCase() + errorMessage.slice(1)
+    : 'No connection';
 };
 
 export const getDefaultErrorMessages = (status: number) => {


### PR DESCRIPTION
- Code view is fully refreshed when closing the Details card or the Contents tab
- In OpenAPI mode browser tab title is not the same, as the JSight document title
- JSight code (left) panel stops reacting
- Network connection error does not appear